### PR TITLE
[web]: Allow all settings to be persisted

### DIFF
--- a/packages/web/src/components/AddConversationForm.tsx
+++ b/packages/web/src/components/AddConversationForm.tsx
@@ -1,5 +1,4 @@
 import { useForm } from "@mantine/form";
-import { DEFAULT_CONTEXT, DEFAULT_DRY, DEFAULT_MODEL } from "gpt-turbo";
 import useConversationManager from "../hooks/useConversationManager";
 import {
     Group,
@@ -20,7 +19,7 @@ import React from "react";
 import useSettings from "../hooks/useSettings";
 import usePersistence from "../hooks/usePersistence";
 
-const ModelSelectItem = React.forwardRef<
+export const ModelSelectItem = React.forwardRef<
     HTMLDivElement,
     { label: string; value: string; selected: boolean }
 >(({ label, value, ...restProps }, ref) => {
@@ -58,12 +57,12 @@ export default () => {
     const form = useForm({
         initialValues: {
             apiKey: settings.apiKey,
-            model: DEFAULT_MODEL,
-            context: DEFAULT_CONTEXT,
-            dry: DEFAULT_DRY,
-            disableModeration: "on",
-            stream: true,
-            save: false,
+            model: settings.model,
+            context: settings.context,
+            dry: settings.dry,
+            disableModeration: settings.disableModeration,
+            stream: settings.stream,
+            save: settings.save,
         },
         transformValues: (values) => ({
             ...values,

--- a/packages/web/src/components/Settings.tsx
+++ b/packages/web/src/components/Settings.tsx
@@ -1,7 +1,22 @@
-import { Button, Container, PasswordInput, Stack, Text } from "@mantine/core";
+import {
+    Button,
+    Container,
+    Group,
+    Input,
+    PasswordInput,
+    SegmentedControl,
+    Select,
+    Stack,
+    Switch,
+    Text,
+    Textarea,
+    Tooltip,
+} from "@mantine/core";
 import { useForm } from "@mantine/form";
-import useSettings from "../hooks/useSettings";
+import { closeAllModals } from "@mantine/modals";
 import React from "react";
+import useSettings from "../hooks/useSettings";
+import { ModelSelectItem } from "./AddConversationForm";
 
 export default () => {
     const { setSettings, settings } = useSettings();
@@ -10,9 +25,14 @@ export default () => {
             ...settings,
         },
     });
-
+    const [modelOptions, setModelOptions] = React.useState([
+        { label: "GPT 3.5", value: "gpt-3.5-turbo" },
+        { label: "GPT 4", value: "gpt-4" },
+        { label: "GPT 4 (32k)", value: "gpt-4-32k" },
+    ]);
     const handleSubmit = form.onSubmit((values) => {
         setSettings(values);
+        closeAllModals();
     });
 
     return (
@@ -22,6 +42,81 @@ export default () => {
                     <PasswordInput
                         {...form.getInputProps("apiKey")}
                         label="OpenAI API Key"
+                    />
+                    <Group>
+                        <Select
+                            {...form.getInputProps("model")}
+                            label="Model"
+                            searchable
+                            creatable
+                            itemComponent={ModelSelectItem}
+                            data={modelOptions}
+                            getCreateLabel={(query) => query}
+                            onCreate={(query) => {
+                                const item = { value: query, label: query };
+                                setModelOptions((current) => [
+                                    ...current,
+                                    item,
+                                ]);
+                                return item;
+                            }}
+                            sx={{ flexGrow: 1 }}
+                        />
+                        <Group position="center" sx={{ flexGrow: 1 }}>
+                            <Input.Wrapper label="Moderation">
+                                <div>
+                                    <SegmentedControl
+                                        {...form.getInputProps(
+                                            "disableModeration"
+                                        )}
+                                        color="blue"
+                                        data={[
+                                            { label: "On", value: "on" },
+                                            { label: "Soft", value: "soft" },
+                                            { label: "Off", value: "off" },
+                                        ]}
+                                    />
+                                </div>
+                            </Input.Wrapper>
+                        </Group>
+                        <Group position="center" noWrap sx={{ flexGrow: 1 }}>
+                            <Tooltip
+                                label="Dry mode is enabled when no API key is specified"
+                                disabled={!!form.values.apiKey}
+                            >
+                                <Input.Wrapper label="Dry">
+                                    <Switch
+                                        {...form.getInputProps("dry")}
+                                        checked={
+                                            !form.values.apiKey ||
+                                            form.values.dry
+                                        }
+                                        readOnly={!form.values.apiKey}
+                                    />
+                                </Input.Wrapper>
+                            </Tooltip>
+                            <Input.Wrapper label="Stream">
+                                <Switch
+                                    {...form.getInputProps("stream", {
+                                        type: "checkbox",
+                                    })}
+                                />
+                            </Input.Wrapper>
+                            <Input.Wrapper label="Save">
+                                <Switch
+                                    {...form.getInputProps("save", {
+                                        type: "checkbox",
+                                    })}
+                                />
+                            </Input.Wrapper>
+                        </Group>
+                    </Group>
+                    <Textarea
+                        {...form.getInputProps("context")}
+                        autosize
+                        minRows={3}
+                        maxRows={5}
+                        label="Context"
                     />
                     <Button type="submit">Save</Button>
                     <Text size="xs" italic align="center">

--- a/packages/web/src/contexts/SettingsContext.ts
+++ b/packages/web/src/contexts/SettingsContext.ts
@@ -1,6 +1,5 @@
 import { DEFAULT_CONTEXT, DEFAULT_DRY, DEFAULT_MODEL } from "gpt-turbo";
 import React from "react";
-
 import makeNotImplemented from "../utils/makeNotImplemented";
 import { Settings } from "../entities/settings";
 

--- a/packages/web/src/contexts/SettingsContext.ts
+++ b/packages/web/src/contexts/SettingsContext.ts
@@ -1,4 +1,6 @@
+import { DEFAULT_CONTEXT, DEFAULT_DRY, DEFAULT_MODEL } from "gpt-turbo";
 import React from "react";
+
 import makeNotImplemented from "../utils/makeNotImplemented";
 import { Settings } from "../entities/settings";
 
@@ -12,6 +14,12 @@ const notImplemented = makeNotImplemented("SettingsContext");
 export const SettingsContext = React.createContext<SettingsContextValue>({
     settings: {
         apiKey: "",
+        model: DEFAULT_MODEL,
+        context: DEFAULT_CONTEXT,
+        dry: DEFAULT_DRY,
+        disableModeration: "on",
+        stream: true,
+        save: false,
     },
     setSettings: notImplemented,
     areSettingsLoaded: false,

--- a/packages/web/src/contexts/providers/SettingsProvider.tsx
+++ b/packages/web/src/contexts/providers/SettingsProvider.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { DEFAULT_CONTEXT, DEFAULT_DRY, DEFAULT_MODEL } from "gpt-turbo";
+
 import { SettingsContext, SettingsContextValue } from "../SettingsContext";
 import useStorage from "../../hooks/useStorage";
 import { Settings, settingsSchema } from "../../entities/settings";
@@ -16,6 +18,12 @@ export default ({ children }: SettingsProviderProps) => {
         "gpt-turbo-settings",
         {
             apiKey: "",
+            model: DEFAULT_MODEL,
+            context: DEFAULT_CONTEXT,
+            dry: DEFAULT_DRY,
+            disableModeration: "on",
+            stream: true,
+            save: false,
         },
         settingsSchema
     );

--- a/packages/web/src/entities/settings.ts
+++ b/packages/web/src/entities/settings.ts
@@ -2,6 +2,12 @@ import { z } from "zod";
 
 export const settingsSchema = z.object({
     apiKey: z.string(),
+    model: z.string(),
+    context: z.string(),
+    dry: z.boolean(),
+    disableModeration: z.boolean().or(z.enum(["on", "soft", "off"])),
+    stream: z.boolean(),
+    save: z.boolean(),
 });
 
 export type Settings = z.infer<typeof settingsSchema>;


### PR DESCRIPTION
## Scope

- [ ] Library
- Implementations
  - [ ] CLI
  - [X] Web
  - [ ] Nest
- [ ] Other:

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Enhancement of an existing feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other:

---

- [ ] Breaking change


## Checklist

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [X] I Ran `npm run lint:fix` **at the monorepo root** to fix linting and formatting errors.
- [X] I Ran `npm run lint:strict` **at the monorepo root** to check for linting errors/warnings and there are none.
- [X] I Ran `npm run build` **at the monorepo root** and there are no errors.
- [X] I have updated the documentation accordingly, if applicable.

## Description

Currently you can only persist the API key, so all other settings have to be entered again for each new conversation. This is particularly frustrating when using a custom context as you have to copy/paste it in each time.

This PR allows all settings to be persisted, so you can set a custom context in the settings modal and have it auto-populate for every new conversation.