### PR TITLE
[Minor] Lerna is a global module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "root",
   "scripts": {
-    "bootstrap": "lerna bootstrap",
-    "clean": "lerna clean --yes && rm -rf node_modules",
+    "bootstrap": "node ./node_modules/lerna/dist/cli.js bootstrap",
+    "clean": "node ./node_modules/lerna/dist/cli.js clean --yes && rm -rf node_modules",
     "reinstall": "npm run clean && npm i && npm run bootstrap",
-    "dev": "lerna run build --scope \"gpt-turbo\" && lerna watch --scope \"gpt-turbo\" --include-dependencies -- lerna run build --scope=\"gpt-turbo\"",
-    "build": "lerna run build",
-    "lint:strict": "lerna run lint:strict",
-    "lint:fix": "lerna run lint:fix",
-    "release": "npm run build && lerna publish",
-    "release:patch": "npm run build && lerna publish patch --yes",
-    "release:minor": "npm run build && lerna publish minor --yes",
-    "release:major": "npm run build && lerna publish major --yes"
+    "dev": "node ./node_modules/lerna/dist/cli.js run build --scope \"gpt-turbo\" && node ./node_modules/lerna/dist/cli.js watch --scope \"gpt-turbo\" --include-dependencies -- node ./node_modules/lerna/dist/cli.js run build --scope=\"gpt-turbo\"",
+    "build": "node ./node_modules/lerna/dist/cli.js run build",
+    "lint:strict": "node ./node_modules/lerna/dist/cli.js run lint:strict",
+    "lint:fix": "node ./node_modules/lerna/dist/cli.js run lint:fix",
+    "release": "npm run build && node ./node_modules/lerna/dist/cli.js publish",
+    "release:patch": "npm run build && node ./node_modules/lerna/dist/cli.js publish patch --yes",
+    "release:minor": "npm run build && node ./node_modules/lerna/dist/cli.js publish minor --yes",
+    "release:major": "npm run build && node ./node_modules/lerna/dist/cli.js publish major --yes"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Description

`lerna` was installed as a dev dependency, but the global module was used in the package scripts.
Running `npm install` won't install `lerna` as a global module

I did not have `lerna` installed as a global module, so the package scripts would not work, even after installing dev dependencies

## Fix

The fix was to use the dev dependency in the package scripts (`./node_modules/lerna/dist/cli.js` and not `lerna`)


## Scope

<!-- Which part of the project is affected by the pull request? Check all that apply. -->

- [ ] Library
- Implementations
  - [ ] CLI
  - [ ] Web
  - [ ] Nest
- [x] Other: package scripts

## Type of change

<!-- Please select the relevant option -->

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactoring
- [ ] Documentation update
- [x] Other: Package scripts

---

<!-- Indicate whether the change is a breaking change -->

- [ ] Breaking change: <!-- If yes, please describe the impact -->


## Checklist


I did not run any linting script since it is not related to the source code.

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [ ] I Ran `npm run lint:fix` **at the monorepo root** to fix linting and formatting errors.
- [ ] I Ran `npm run lint:strict` **at the monorepo root** to check for linting errors/warnings and there are none.
- [ ] I Ran `npm run build` **at the monorepo root** and there are no errors.
- [x] I have updated the documentation accordingly, if applicable.


